### PR TITLE
Improved plot_predictions helper

### DIFF
--- a/deeplearning2020/helpers.py
+++ b/deeplearning2020/helpers.py
@@ -14,7 +14,7 @@ def plot_predictions(
     mdl: "keras.models.Model",
     inputs: np.ndarray,
     labels: typing.Optional[np.ndarray] = None,
-    classes: typing.Optional[typing.List[int]] = None,
+    label_names: typing.Optional[typing.List[int]] = None,
     images: typing.Optional[np.ndarray] = None,
     max_cols: int = 3,
     figsize: typing.Tuple[int, int] = (3, 2),
@@ -29,34 +29,37 @@ def plot_predictions(
         num_rows, num_cols, figsize=(figsize[0] * num_cols, figsize[1] * num_rows)
     )
     model_predictions = mdl.predict(inputs)
-    if classes is None:
-        classes = list(range(len(model_predictions[0])))
+    if label_names is None:
+        label_names = list(range(len(model_predictions[0])))
     if images is None:
         images = inputs
     else:
-        assert len(classes) == len(
+        assert len(label_names) == len(
             model_predictions[0]
-        ), "Need as many classes as there are output neurons"
+        ), "Need as many class names as there are output neurons"
     for r in range(num_rows):
         for c in range(num_cols):
             i = r * num_cols + c
             if not i < len(inputs):
                 continue
-            predicted_label = classes[np.argmax(model_predictions[i])]
+            predicted_label = np.argmax(model_predictions[i])
+            expected_label = np.argmax(labels[i])
+            pred_correct = predicted_label == expected_label
             if labels is None:
                 color = "blue"
             else:
                 color, weight = (
                     ("green", "normal")
-                    if predicted_label == np.argmax(labels[i])
+                    if pred_correct
                     else ("red", "extra bold")
                 )
             plots[r][c].tick_params(top=False, bottom=False, left=False, right=False)
             plots[r][c].imshow(images[i], cmap=plt.cm.binary)
             plots[r][c].axis("off")
-            plots[r][c].set_title(
-                "Predicted {}".format(predicted_label), color=color, weight=weight
-            )
+            if pred_correct:
+              plots[r][c].set_title("{}".format(label_names[predicted_label]), color=color, weight=weight)
+            else:
+              plots[r][c].set_title("P: {}, E: {}".format(label_names[predicted_label], label_names[expected_label]), color=color, weight=weight)
 
 
 def plot_worst(

--- a/deeplearning2020/helpers.py
+++ b/deeplearning2020/helpers.py
@@ -9,8 +9,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from tf.keras.callbacks import History
     from tf.python.data.ops.dataset_ops import DatasetV1Adapter
 
-
-def plot_predictions(
+def my_plot_predictions(
     mdl: "keras.models.Model",
     inputs: np.ndarray,
     labels: typing.Optional[np.ndarray] = None,
@@ -25,18 +24,14 @@ def plot_predictions(
         assert len(inputs) == len(labels), "Need as many labels as inputs!"
     num_cols = min(len(inputs), max_cols)
     num_rows = int(len(inputs) / num_cols)
-    fig, plots = plt.subplots(
-        num_rows, num_cols, figsize=(figsize[0] * num_cols, figsize[1] * num_rows)
-    )
+    fig, plots = plt.subplots(num_rows, num_cols, figsize=(figsize[0] * num_cols, figsize[1] * num_rows))
     model_predictions = mdl.predict(inputs)
     if label_names is None:
         label_names = list(range(len(model_predictions[0])))
     if images is None:
         images = inputs
     else:
-        assert len(label_names) == len(
-            model_predictions[0]
-        ), "Need as many class names as there are output neurons"
+        assert len(label_names) == len(model_predictions[0]), "Need as many class names as there are output neurons"
     for r in range(num_rows):
         for c in range(num_cols):
             i = r * num_cols + c
@@ -44,22 +39,16 @@ def plot_predictions(
                 continue
             predicted_label = np.argmax(model_predictions[i])
             expected_label = np.argmax(labels[i])
-            pred_correct = predicted_label == expected_label
+            prediction_correct = predicted_label == expected_label
+            title = "{}".format(label_names[predicted_label]) if prediction_correct else "P: {}, E: {}".format(label_names[predicted_label], label_names[expected_label])
             if labels is None:
-                color = "blue"
+                color, weight = ("blue", "normal")
             else:
-                color, weight = (
-                    ("green", "normal")
-                    if pred_correct
-                    else ("red", "extra bold")
-                )
+                color, weight = ("green", "light") if prediction_correct else ("red", "bold")
             plots[r][c].tick_params(top=False, bottom=False, left=False, right=False)
             plots[r][c].imshow(images[i], cmap=plt.cm.binary)
             plots[r][c].axis("off")
-            if pred_correct:
-              plots[r][c].set_title("{}".format(label_names[predicted_label]), color=color, weight=weight)
-            else:
-              plots[r][c].set_title("P: {}, E: {}".format(label_names[predicted_label], label_names[expected_label]), color=color, weight=weight)
+            plots[r][c].set_title(title, color=color, weight=weight)
 
 
 def plot_worst(

--- a/deeplearning2020/helpers.py
+++ b/deeplearning2020/helpers.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from tf.keras.callbacks import History
     from tf.python.data.ops.dataset_ops import DatasetV1Adapter
 
-def my_plot_predictions(
+def plot_predictions(
     mdl: "keras.models.Model",
     inputs: np.ndarray,
     labels: typing.Optional[np.ndarray] = None,


### PR DESCRIPTION
My improved plot_predictions helper shows literals for number labels if provided. Can be useful e.g. with Zalando MNIST set. In case of a wrong prediction it shows the expected class, too.

Usage example:

```
label_names = ["T-shirt/top", "Trouser", "Pullover", "Dress", "Coat", "Sandal", "Shirt", "Sneaker", "Bag", "Ankle boot"]
plot_predictions(model, test_images[:40], labels = test_vec_labels[:40], label_names = label_names, max_cols = 5)
```

Result:
![Screenshot_Google_Colaboratory](https://user-images.githubusercontent.com/7488479/78137702-12ba4d00-7426-11ea-9d62-6b57e0c0cb23.png)
